### PR TITLE
Saga 2.98/responsive main navigation components

### DIFF
--- a/src/components/button/button.styles.tsx
+++ b/src/components/button/button.styles.tsx
@@ -180,7 +180,7 @@ export const buttonText = (
     ${icon &&
     size !== ButtonSize.Flexible &&
     `justify-content: space-around;
-    width: 100%;`}
+    width: 100%; align-items: center;`}
 `;
 
 export const buttonSubtext = (theme: Theme) => css`

--- a/src/components/header/Header.styles.tsx
+++ b/src/components/header/Header.styles.tsx
@@ -16,7 +16,7 @@ export const header = (theme: Theme, backgroundImage: any) => css`
     font-family: ${theme.fonts.robotoBold};
     color: ${Colors.White};
     text-align: left;
-    @media (max-width: ${theme.breakpoints.sm}px) {
+    @media (max-width: ${theme.breakpoints.lg}px) {
         border-radius: 0;
         padding: 8rem 1rem 2rem;
         margin: 0 -1rem;
@@ -29,7 +29,7 @@ export const headerTitle = (theme: Theme) => css`
     padding: 1.5rem 0 1rem 2.31rem;
     text-shadow: -1px 1px 1px ${Colors.TextShadowLight},
         -2px 2px 1px ${Colors.TextShadowExtraLight};
-    @media (max-width: ${theme.breakpoints.sm}px) {
+    @media (max-width: ${theme.breakpoints.md}px) {
         font-size: ${theme.fontSizes.h1Mobile};
         line-height: 30px;
         padding: 0.25rem 0 1rem 0;
@@ -45,7 +45,7 @@ export const headerDetails = (theme: Theme) => css`
     font-size: ${theme.fontSizes.pSmall};
     line-height: 16px;
     letter-spacing: 0.3px;
-    @media (max-width: ${theme.breakpoints.sm}px) {
+    @media (max-width: ${theme.breakpoints.md}px) {
         font-size: ${theme.fontSizes.pSmallMobile};
         flex-direction: column;
         align-items: flex-start;
@@ -56,7 +56,7 @@ export const headerDates = (theme: Theme) => css`
     padding: 0 0 0.75rem 2.31rem;
     text-shadow: -1px 1px 1px ${Colors.TextShadowMedium},
         -2px 2px 1px ${Colors.TextShadowExtraLight};
-    @media (max-width: ${theme.breakpoints.sm}px) {
+    @media (max-width: ${theme.breakpoints.md}px) {
         padding: 0 0 0.3rem 0;
         flex-basis: 100%;
     }
@@ -68,8 +68,8 @@ export const headerLocation = (theme: Theme) => css`
     padding: 0 0 0.75rem 1.5rem;
     text-shadow: -1px 1px 1px ${Colors.TextShadowMedium},
         -2px 2px 1px ${Colors.TextShadowExtraLight};
-    @media (max-width: ${theme.breakpoints.sm}px) {
-        padding: 0 0 .25rem 0;
+    @media (max-width: ${theme.breakpoints.md}px) {
+        padding: 0 0 0.25rem 0;
         flex-basis: 100%;
     }
 `;

--- a/src/components/mainContent/mainContent.styles.tsx
+++ b/src/components/mainContent/mainContent.styles.tsx
@@ -7,7 +7,7 @@ export const mainContent = (theme: Theme) => css`
     background-color: ${Colors.PrimaryContentBackground};
     font-family: ${theme.fonts.robotoBold};
     width: 100%;
-    @media (max-width: ${theme.breakpoints.sm}px) {
+    @media (max-width: ${theme.breakpoints.lg}px) {
         border-radius: 0;
         padding: 5rem 1rem 2rem 1rem;
     }

--- a/src/components/mainNavigation/MainNavigation.styles.tsx
+++ b/src/components/mainNavigation/MainNavigation.styles.tsx
@@ -32,6 +32,13 @@ export const mainNavigationSmallContainer = css`
 `;
 export const mainNavigationItemContainer = () => css`
     padding: 2rem 0;
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+    min-height: 100vh;
+    overflow-y: auto;
+    background-color: ${Colors.White};
 `;
 export const mainNavigationLogo = (theme: Theme) => css`
     @media (min-width: ${theme.breakpoints.md + 1}px) {

--- a/src/components/mainNavigation/MainNavigation.styles.tsx
+++ b/src/components/mainNavigation/MainNavigation.styles.tsx
@@ -6,7 +6,7 @@ export const mainNavigation = (theme: Theme) => css`
     @media (min-width: ${theme.breakpoints.lg + 1}px) {
         padding: 1.5rem 3.5rem 3rem 2rem;
     }
-    @media (max-width: ${theme.breakpoints.md}px) {
+    @media (max-width: ${theme.breakpoints.lg}px) {
         width: 100%;
         position: fixed;
         z-index: 1200;
@@ -15,20 +15,14 @@ export const mainNavigation = (theme: Theme) => css`
     box-sizing: border-box;
     background-color: ${Colors.White};
 `;
-export const mainNavigationMainContainer = (
-    theme: Theme,
-    anchor: boolean
-) => css`
+export const mainNavigationMainContainer = (theme: Theme) => css`
     display: flex;
     justify-content: space-between;
     @media (max-width: ${theme.breakpoints.lg}px) {
-        padding: 1.5rem;
+        padding: 1.5rem 1.5rem 1rem 1.5rem;
     }
     @media (max-width: ${theme.breakpoints.md}px) {
         padding: 1.5rem 0 1rem 0;
-        ${anchor === true &&
-        `position: sticky; background: white; 
-        top: 0;`}
     }
 `;
 export const mainNavigationSmallContainer = css`

--- a/src/components/mainNavigation/MainNavigation.tsx
+++ b/src/components/mainNavigation/MainNavigation.tsx
@@ -34,7 +34,6 @@ const MainNavigation: React.FC<MainNavigationProps> = ({
     profileImageUrl,
     onClickProfileImage,
     secondaryItems,
-    anchor = false,
     className,
     menuItems,
     onMobileMenuOpen,
@@ -67,7 +66,7 @@ const MainNavigation: React.FC<MainNavigationProps> = ({
             css={mainNavigation(theme)}
             className={className}
         >
-            <div css={mainNavigationMainContainer(theme, anchor)}>
+            <div css={mainNavigationMainContainer(theme)}>
                 <div css={mainNavigationSmallContainer}>
                     <div>
                         <img

--- a/src/components/sidebar/Sidebar.styles.tsx
+++ b/src/components/sidebar/Sidebar.styles.tsx
@@ -11,12 +11,12 @@ export const sidebar = (theme: Theme) => css`
         position: fixed;
         width: 100%;
         height: 100%;
-        z-index: 1;
+        z-index: 3;
         min-height: 100vh;
         overflow-y: auto;
     }
 
-    padding: 5rem 2rem 2rem;
+    padding: 5rem 1rem 2rem;
     box-sizing: border-box;
     background-color: ${Colors.White};
 `;

--- a/src/components/sidebar/Sidebar.styles.tsx
+++ b/src/components/sidebar/Sidebar.styles.tsx
@@ -3,17 +3,20 @@ import { css, Theme } from '@emotion/react';
 import { Colors } from '../../shared/constants/colors';
 
 export const sidebar = (theme: Theme) => css`
-    @media (min-width: ${theme.breakpoints.md + 1}px) {
+    @media (min-width: ${theme.breakpoints.lg + 1}px) {
         min-width: 274px;
+        padding: 0 2rem;
     }
-    @media (max-width: ${theme.breakpoints.md}px) {
+    @media (max-width: ${theme.breakpoints.lg}px) {
         position: fixed;
         width: 100%;
         height: 100%;
         z-index: 1;
         min-height: 100vh;
+        overflow-y: auto;
     }
-    padding: 0rem 2rem;
+
+    padding: 5rem 2rem 2rem;
     box-sizing: border-box;
     background-color: ${Colors.White};
 `;

--- a/src/components/sidebar/SidebarItem.styles.tsx
+++ b/src/components/sidebar/SidebarItem.styles.tsx
@@ -5,15 +5,14 @@ export const sidebarItem = (theme: Theme, selected: boolean) => css`
     background-color: white;
     border-radius: 13px;
     font-family: ${theme.fonts.robotoBold};
-    padding: 0.5rem 1rem;
+    padding: 0.75rem 1rem;
     cursor: pointer;
     &:hover {
         background-color: #eff1f7;
         transition: 0.5s;
     }
-    margin: 0.5rem 0rem;
     &:last-child {
-        margin: 0.5rem 0 2rem 0;
+        padding: 0.75rem 1rem 2rem;
     }
     ${selected === true && `background-color: #eff1f7;`}
 `;

--- a/src/components/sidebar/SidebarMenu.styles.tsx
+++ b/src/components/sidebar/SidebarMenu.styles.tsx
@@ -7,15 +7,23 @@ export const sidebarMenu = css`
 export const sidebarMenuDiv = css`
     display: flex;
     justify-content: space-between;
+    align-items: center;
+    padding: 0 0.5rem 1rem 0.5rem;
 `;
 export const sidebarMenuTitle = (theme: Theme) => css`
     text-transform: uppercase;
     font-size: 13px;
     line-height: 15px;
     font-family: ${theme.fonts.robotoBold};
-    padding: 0 0 1rem 1rem;
     color: ${Colors.Gray};
 `;
-export const sidebarMenuDivImg = css`
-    padding: 0 1rem 0.7rem 0;
+
+export const sidebarMenuOpenImage = css`
+    transform: rotate(0deg);
+    transition: all 0.5s;
+`;
+
+export const sidebarMenuCloseImage = css`
+    transform: rotate(-90deg);
+    transition: all 0.5s;
 `;

--- a/src/components/sidebar/SidebarMenu.tsx
+++ b/src/components/sidebar/SidebarMenu.tsx
@@ -8,7 +8,8 @@ import {
     sidebarMenu,
     sidebarMenuDiv,
     sidebarMenuTitle,
-    sidebarMenuDivImg,
+    sidebarMenuCloseImage,
+    sidebarMenuOpenImage,
 } from './SidebarMenu.styles';
 import imgArrow from '../../shared/images/icons/small gray arrow.svg';
 
@@ -36,7 +37,21 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
         >
             <div css={sidebarMenuDiv} onClick={() => toggle()}>
                 <h5 css={sidebarMenuTitle(theme)}>{title}</h5>
-                <img alt="Arrow" src={imgArrow} css={sidebarMenuDivImg} />
+                {openMenu ? (
+                    <img
+                        alt="Open"
+                        src={imgArrow}
+                        css={sidebarMenuOpenImage}
+                        onClick={() => toggle()}
+                    />
+                ) : (
+                    <img
+                        alt="Close"
+                        src={imgArrow}
+                        css={sidebarMenuCloseImage}
+                        onClick={() => toggle()}
+                    />
+                )}
             </div>
             {openMenu ? children : null}
         </div>

--- a/src/components/sidebar/SidebarMenu.tsx
+++ b/src/components/sidebar/SidebarMenu.tsx
@@ -29,29 +29,24 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
         }
         setOpenMenu(!openMenu);
     }, [openMenu]);
+
+    const altText = openMenu ? 'Open' : 'Close';
+    const sidebarCss = openMenu ? sidebarMenuOpenImage : sidebarMenuCloseImage;
+
     return (
         <div
             data-testid="sidebar__menu"
             css={sidebarMenu}
             className={className}
         >
-            <div css={sidebarMenuDiv} onClick={() => toggle()}>
+            <div css={sidebarMenuDiv} onClick={toggle}>
                 <h5 css={sidebarMenuTitle(theme)}>{title}</h5>
-                {openMenu ? (
-                    <img
-                        alt="Open"
-                        src={imgArrow}
-                        css={sidebarMenuOpenImage}
-                        onClick={() => toggle()}
+                <img
+                    alt={altText}
+                    src={imgArrow}
+                    css={sidebarCss}
+                    onClick={toggle}
                     />
-                ) : (
-                    <img
-                        alt="Close"
-                        src={imgArrow}
-                        css={sidebarMenuCloseImage}
-                        onClick={() => toggle()}
-                    />
-                )}
             </div>
             {openMenu ? children : null}
         </div>


### PR DESCRIPTION
New mobile styles for the Sidebar/MainNavigation after the changes that have been implemented to handle dynamic display on the sidebar.

- Fixing the second vertical scroll on the sidebar when is expanded
- Fixing the layer height for the first level of navigation (trips and itineraries). Making it full screen.
- Styling and spacing the inner menu from desktop to mobile devices
- Adding the style for the arrow icon to collapse and expand the menu

This is a branch built together with maven's branch: saga-2.98/responsive-main-navigation
In Asana: https://asanal.ink/21/98 
https://asanal.ink/21/98